### PR TITLE
Hover dim delay

### DIFF
--- a/network/js/main.js
+++ b/network/js/main.js
@@ -208,36 +208,36 @@ function configSigmaElements(config) {
     if (config.features.hoverBehavior == "dim") {
         var outTimeoutID;
         var overTimeoutID;
-		var greyColor = '#ccc';
-		sigInst.bind('overnodes',function(event){
+        var greyColor = '#ccc';
+        sigInst.bind('overnodes', function(event) {
         var dimIn = function(event) {
             var nodes = event.content;
             var neighbors = {};
             sigInst.iterEdges(function(e){
             if(nodes.indexOf(e.source)<0 && nodes.indexOf(e.target)<0){
                 if(!e.attr['grey']){
-                	e.attr['true_color'] = e.color;
-                	e.color = greyColor;
-                	e.attr['grey'] = 1;
+                    e.attr['true_color'] = e.color;
+                    e.color = greyColor;
+                    e.attr['grey'] = 1;
                 }
             }else{
-            	e.color = e.attr['grey'] ? e.attr['true_color'] : e.color;
-            	e.attr['grey'] = 0;
+                e.color = e.attr['grey'] ? e.attr['true_color'] : e.color;
+                e.attr['grey'] = 0;
 
-            	neighbors[e.source] = 1;
-            	neighbors[e.target] = 1;
+                neighbors[e.source] = 1;
+                neighbors[e.target] = 1;
             }
             }).iterNodes(function(n){
-            	if(!neighbors[n.id]){
-            		if(!n.attr['grey']){
-            			n.attr['true_color'] = n.color;
-            			n.color = greyColor;
-            			n.attr['grey'] = 1;
-                	}
+                if (!neighbors[n.id]) {
+                    if (!n.attr['grey']) {
+                        n.attr['true_color'] = n.color;
+                        n.color = greyColor;
+                        n.attr['grey'] = 1;
+                     }
                 }else{
-                	n.color = n.attr['grey'] ? n.attr['true_color'] : n.color;
-            		n.attr['grey'] = 0;
-            	}
+                    n.color = n.attr['grey'] ? n.attr['true_color'] : n.color;
+                    n.attr['grey'] = 0;
+                }
             }).draw(2,2,2);
         };
         window.clearTimeout(overTimeoutID);
@@ -249,13 +249,13 @@ function configSigmaElements(config) {
                 e.color = e.attr['grey'] ? e.attr['true_color'] : e.color;
                 e.attr['grey'] = 0;
             }).iterNodes(function(n){
-            	n.color = n.attr['grey'] ? n.attr['true_color'] : n.color;
-            	n.attr['grey'] = 0;
+                n.color = n.attr['grey'] ? n.attr['true_color'] : n.color;
+                n.attr['grey'] = 0;
             }).draw(2,2,2);
         };
         window.clearTimeout(outTimeoutID);
         outTimeoutID = window.setTimeout(function(){dimOut();}, 500);
-		});
+        });
 
     } else if (config.features.hoverBehavior == "hide") {
 


### PR DESCRIPTION
When hover behaviour is 'dim', only redraw when over/out events stop firing.
Note: a case still exists with overlaping nodes where the out event is fired last (but the mouse is over a node) preventing the dim.
